### PR TITLE
Use non rounded dividend paid tax to calculate tax deduction

### DIFF
--- a/src/tax_statement/dividends.rs
+++ b/src/tax_statement/dividends.rs
@@ -82,14 +82,15 @@ pub fn process_income(
         let foreign_paid_tax = dividend.paid_tax;
         total_foreign_paid_tax.deposit(foreign_paid_tax);
 
-        let paid_tax = currency::round(converter.convert_to(
-            dividend.date, dividend.paid_tax, country.currency)?);
+        let non_rounded_paid_tax =
+            converter.convert_to(dividend.date, dividend.paid_tax, country.currency)?;
+        let tax_deduction = country.round_tax(non_rounded_paid_tax);
+        let paid_tax = currency::round(non_rounded_paid_tax);
         total_paid_tax += paid_tax;
 
         let tax_to_pay = dividend.tax_to_pay(&country, converter)?;
         total_tax_to_pay += tax_to_pay;
 
-        let tax_deduction = country.round_tax(paid_tax);
         if !tax_to_pay.is_zero() {
             assert_eq!(tax_deduction, tax - tax_to_pay);
         }


### PR DESCRIPTION
Hi, thanks for the app, I got an assert error with my statement
https://github.com/KonishchevDmitry/investments/blob/3c9838306abf64a739f3a58b541b664b5e9ccd72/src/tax_statement/dividends.rs#L94 
The error with some printlns:

```
dividend.amount=616.260636, dividend.paid_tax=61.499261
tax_deduction=62, tax=80, tax_to_pay=19, paid_tax=61.5

thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `62`,
 right: `61`', src/tax_statement/dividends.rs:96:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I think we should use non rounded paid tax value to calculate tax deduction otherwise we round already rounded value.